### PR TITLE
add `xlrd` to Python requirements list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas
+xlrd
 ipyleaflet


### PR DESCRIPTION
required for pandas to read Excel files